### PR TITLE
Normalize User-Agent delimiter

### DIFF
--- a/src/main/java/sh/scarf/ScarfEventLogger.java
+++ b/src/main/java/sh/scarf/ScarfEventLogger.java
@@ -155,7 +155,7 @@ public class ScarfEventLogger {
             String jver = System.getProperty("java.version", "unknown");
             if (jver == null || jver.isBlank()) jver = "unknown";
 
-            extra = " (platform=" + platformName + "; arch=" + arch + ", java=" + jver + ")";
+            extra = " (platform=" + platformName + "; arch=" + arch + "; java=" + jver + ")";
         } catch (Throwable ignored) {
             // fall back to base UA
         }


### PR DESCRIPTION
Fixes #5 by standardizing the extended User-Agent properties to use semicolons throughout: `(platform=...; arch=...; java=...)`.

---
AI-generated change (model: openai-codex/gpt-5.2).
